### PR TITLE
laravel sanctumのtoken認証方式の変更と組み込み

### DIFF
--- a/src/client/src/components/Top/index.tsx
+++ b/src/client/src/components/Top/index.tsx
@@ -1,22 +1,12 @@
 import { Button } from 'src/components/common/Button';
 import { useRouter } from 'next/router';
 import { paths } from 'src/utils/paths';
-import { httpClient } from 'src/utils/httpClient';
-import { BASE_URL } from 'src/utils/constants';
-import { useEffect } from 'react';
+import { useContext } from 'react';
+import { globalContext } from 'src/contexts/globalContext';
 
 export const TopUI = () => {
   const router = useRouter();
-
-  //  TODO ログイン後のユーザーが取得できないs
-  const fetchLoginUser = async () => {
-    const res = await httpClient.get(BASE_URL + '/user');
-    console.log(res);
-  };
-
-  useEffect(() => {
-    fetchLoginUser();
-  }, []);
+  const { token } = useContext(globalContext);
 
   return (
     <>
@@ -33,20 +23,24 @@ export const TopUI = () => {
             }}
             disabled={false}
           />
-          {/* <Button
-            title="新規投稿する"
-            onClick={() => {
-              token ? router.push(paths.articles.add) : router.push(paths.accounts.login);
-            }}
-            disabled={false}
-          />
-          <Button
-            title="マイページ"
-            onClick={() => {
-              token ? router.push(paths.accounts.mypage) : router.push(paths.accounts.login);
-            }}
-            disabled={false}
-          /> */}
+          {token && (
+            <>
+              <Button
+                title="新規投稿する"
+                onClick={() => {
+                  token ? router.push(paths.articles.add) : router.push(paths.accounts.login);
+                }}
+                disabled={false}
+              />
+              <Button
+                title="マイページ"
+                onClick={() => {
+                  token ? router.push(paths.accounts.mypage) : router.push(paths.accounts.login);
+                }}
+                disabled={false}
+              />
+            </>
+          )}
         </div>
       </div>
       <style jsx>{``}</style>

--- a/src/client/src/components/header/TopHeader.tsx
+++ b/src/client/src/components/header/TopHeader.tsx
@@ -1,15 +1,11 @@
 import { useRouter } from 'next/router';
-import { useState, useEffect } from 'react';
+import React, { useContext } from 'react';
+import { globalContext } from 'src/contexts/globalContext';
 import { paths } from 'src/utils/paths';
-import { getToken } from 'src/utils/getToken';
 
-export const TopHeader = () => {
+export const TopHeader: React.FC = () => {
   const router = useRouter();
-  const [loginToken, setLoginToken] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoginToken(getToken());
-  }, []);
+  const { token } = useContext(globalContext);
 
   return (
     <>
@@ -17,7 +13,7 @@ export const TopHeader = () => {
         <div className="lg:w-2/4 flex justify-between mx-auto h-12">
           <div className="my-auto	mx-0">タイトル名</div>
           <div className="lg:w-3/12 flex justify-between">
-            {loginToken ? (
+            {token ? (
               <>
                 <button
                   className="my-auto	lg:mx-0 mr-3"
@@ -30,7 +26,8 @@ export const TopHeader = () => {
                 <button
                   className="my-auto	lg:mx-0 mr-3"
                   onClick={() => {
-                    alert('未実装');
+                    localStorage.removeItem('auth-token');
+                    router.reload();
                   }}
                 >
                   ログアウト

--- a/src/client/src/contexts/globalContext.tsx
+++ b/src/client/src/contexts/globalContext.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from 'react';
+
+type GlobalContextState = {
+  token: string | null;
+  setToken: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const globalContextState: GlobalContextState = {
+  token: null,
+  // eslint-disable-next-line  @typescript-eslint/no-empty-function
+  setToken: () => {},
+};
+
+export const globalContext = React.createContext<GlobalContextState>(globalContextState);
+
+export const GlobalContextWrapper = ({ children }) => {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    setToken(localStorage.getItem('auth-token'));
+  }, []);
+
+  return <globalContext.Provider value={{ token, setToken }}>{children}</globalContext.Provider>;
+};

--- a/src/client/src/hooks/accounts/login/index.ts
+++ b/src/client/src/hooks/accounts/login/index.ts
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useRouter } from 'next/router';
 import { paths } from 'src/utils/paths';
 import { useSnackbar } from 'notistack';
-import { BASE_URL, AUTH_INIT_ENDPOINT } from 'src/utils/constants';
+import { BASE_URL } from 'src/utils/constants';
 import { httpClient } from 'src/utils/httpClient';
+import { globalContext } from 'src/contexts/globalContext';
 
 export type Validator = {
   isValidInputEmail: () => boolean;
@@ -14,6 +15,7 @@ export type Validator = {
 export const useLogin = () => {
   const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
+  const { setToken } = useContext(globalContext);
   const [inputEmail, setInputEmail] = useState<string | null>(null);
   const [inputPassword, setInputPassword] = useState<string | null>(null);
 
@@ -30,17 +32,15 @@ export const useLogin = () => {
 
   const handleClickLogin = async () => {
     try {
-      const authInitRes = await httpClient.get(AUTH_INIT_ENDPOINT);
-
-      if (authInitRes.status) {
-        const params = {
-          email: inputEmail,
-          password: inputPassword,
-        };
-        const loginRes = await httpClient.post(LOGIN_ENDPOINT, params);
-        if (loginRes.status === 200) {
-          router.push(paths.top);
-        }
+      const params = {
+        email: inputEmail,
+        password: inputPassword,
+      };
+      const res = await httpClient.post(LOGIN_ENDPOINT, params);
+      if (res.status === 200) {
+        localStorage.setItem('auth-token', res.data.user.token);
+        setToken(localStorage.getItem('auth-token'));
+        router.push(paths.top);
       }
     } catch (e) {
       enqueueSnackbar(e.message, { variant: 'error' });

--- a/src/client/src/pages/_app.tsx
+++ b/src/client/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import './styles.css';
 import { SnackbarProvider } from 'notistack';
 import Slide from '@material-ui/core/Slide';
+import { GlobalContextWrapper } from 'src/contexts/globalContext';
 
 function App({ Component, pageProps }) {
   return (
@@ -13,7 +14,9 @@ function App({ Component, pageProps }) {
       TransitionComponent={Slide}
       autoHideDuration={3000}
     >
-      <Component {...pageProps} />;
+      <GlobalContextWrapper>
+        <Component {...pageProps} />;
+      </GlobalContextWrapper>
     </SnackbarProvider>
   );
 }

--- a/src/client/src/utils/httpClient.ts
+++ b/src/client/src/utils/httpClient.ts
@@ -4,4 +4,4 @@ import axios from 'axios';
  * laravel sanctumドキュメントを参照し「withCredentials:true;」
  * https://readouble.com/laravel/8.x/ja/sanctum.html#spa-authentication
  */
-export const httpClient = axios.create({ withCredentials: true });
+export const httpClient = axios.create({ headers: { 'Content-Type': 'application/json' }, withCredentials: true });

--- a/src/laravel/app/Models/User.php
+++ b/src/laravel/app/Models/User.php
@@ -9,29 +9,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Sanctum\HasApiTokens;
 
-/**
- * App\Models\User
- *
- * @property string $user_id
- * @property string $name
- * @property string $email
- * @property string $password
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Illuminate\Notifications\DatabaseNotificationCollection|\Illuminate\Notifications\DatabaseNotification[] $notifications
- * @property-read int|null $notifications_count
- * @method static \Database\Factories\UserFactory factory(...$parameters)
- * @method static \Illuminate\Database\Eloquent\Builder|User newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|User newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|User query()
- * @method static \Illuminate\Database\Eloquent\Builder|User whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereEmail($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereName($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User wherePassword($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereUpdatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereUserId($value)
- * @mixin \Eloquent
- */
+
 class User extends Authenticatable
 {
     use HasFactory,Notifiable,SoftDeletes,HasApiTokens;

--- a/src/laravel/app/Repositories/Auth/AuthInterface.php
+++ b/src/laravel/app/Repositories/Auth/AuthInterface.php
@@ -5,5 +5,4 @@ namespace App\Repositories\Auth;
 interface AuthInterface
 {
     public function login($request);
-    public function logout($request);
 }

--- a/src/laravel/app/Repositories/Auth/AuthRepository.php
+++ b/src/laravel/app/Repositories/Auth/AuthRepository.php
@@ -3,14 +3,9 @@
 namespace App\Repositories\Auth;
 
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class AuthRepository implements AuthInterface
 {
-    //テスト実施後は仮データの削除
-    use RefreshDatabase;
-
-
     public function login($request)
     {
         $credentials = $request->validate([
@@ -29,7 +24,7 @@ class AuthRepository implements AuthInterface
             // $user->token = $user->createToken("test")->plainTextToken;
             $user->token = $user->createToken($user->name)->plainTextToken;
             
-            return response()->messageAndStatusCode(['user' => $user], 200);
+            return response()->json(['user' => $user], 200);
         }
 
         return response()->messageAndStatusCode('ユーザーが見つかりません。', 404);

--- a/src/laravel/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/src/laravel/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -15,7 +15,7 @@ class CreatePersonalAccessTokensTable extends Migration
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->morphs('tokenable');
+            $table->uuidMorphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();

--- a/src/laravel/tests/Feature/AuthTest.php
+++ b/src/laravel/tests/Feature/AuthTest.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Hash;
 use App\Models\User;
 use Tests\TestCase;
 
-
 class AuthTest extends TestCase
 {
     //テスト実施後は仮データの削除
@@ -32,7 +31,8 @@ class AuthTest extends TestCase
     public function testLoginSuccess()
     {
         $request = ['email' => $this->email,'password'=>$this->password];
-        $response = $this->postJson('/api/login',$request);
+        $response = $this->postJson('/api/login', $request);
+        dump($response);
         $response->assertStatus(200);
     }
     
@@ -43,7 +43,7 @@ class AuthTest extends TestCase
     public function testLoginFailedInvalidInput()
     {
         $request = ['email' => 'failed@example.com','password'=>$this->password];
-        $response = $this->postJson('/api/login',$request);
+        $response = $this->postJson('/api/login', $request);
         $response->assertStatus(404);
     }
     


### PR DESCRIPTION
### 対応背景
ドメインが異なる場合のCookie認証は対応が多いかつ、googleはサードパーティ製cookieの規制を厳しくする方針にあるため

### 対応内容

- laravel sanctum内でもbearer token認証に変更